### PR TITLE
Fix assessments issue and update changelog

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file from v1.0.0.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v1.3.6] 2025-03-13
+
+### Fixed
+- Fixed issue where a previously obsoleted competency will cause an error on the homepage
+
 ## [v1.3.5] 2025-02-25
 
 ### Fixed

--- a/app/mod_training/views.py
+++ b/app/mod_training/views.py
@@ -286,6 +286,8 @@ def get_competence_summary_by_user(c_id, u_id,version):
     """
     assigned_users = aliased(Users)
 
+    # wrt line 302 we do not want obsolete assessments in 
+    # this table as it causes the index page to error
     competence_result = s.query(Assessments). \
         outerjoin(Users, Users.id == Assessments.user_id). \
         outerjoin(assigned_users, assigned_users.id == Assessments.assign_id). \
@@ -297,6 +299,7 @@ def get_competence_summary_by_user(c_id, u_id,version):
         outerjoin(ValidityRef, CompetenceDetails.validity_period == ValidityRef.id). \
         filter(and_(Users.id == u_id, Competence.id == c_id)). \
         filter(Assessments.version == version).\
+        filter(Assessments.status != 6).\
         group_by(CompetenceDetails.id). \
         values((Users.first_name + ' ' + Users.last_name).label('user'),
                (assigned_users.first_name + ' ' + assigned_users.last_name).label('assigner'),

--- a/app/templates/base2.html
+++ b/app/templates/base2.html
@@ -877,7 +877,7 @@ desired effect
     <footer class="main-footer">
         <!-- To the right -->
         <div class="pull-right hidden-xs">
-            v1.3.5
+            v1.3.6
         </div>
         <!-- Default to the left -->
         <strong>Copyright &copy; 2022 Sheffield Diagnostic Genetics Service & Sheffield Bioinformatics Core.</strong> All rights

--- a/app/templates/login_base.html
+++ b/app/templates/login_base.html
@@ -53,7 +53,7 @@
 <br>
 
 
-<center><span class="label label-default">v1.3.5</span> </center>
+<center><span class="label label-default">v1.3.6</span> </center>
 
 
 {#  <br><br><br>#}

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='CompetenceDB',
-    version='1.3.5',
+    version='1.3.6',
     packages=['app','app.mod_admin','app.mod_competence','app.mod_document','app.mod_training', 'app.mod_hos', 'app.mod_cpd'],
     url='',
     license='',


### PR DESCRIPTION
MRG noticed an issue with a previously obsoleted competency.

This fixes that issue.

The root cause of the issue was obsolete assesments being included in the dashboard list of completed assesments when a user has reassigned themselves a competency that they have previously completed.